### PR TITLE
Optimize canvas rendering pipeline

### DIFF
--- a/index.html
+++ b/index.html
@@ -373,6 +373,113 @@
         const imageUpload2 = document.getElementById('imageUpload2');
         const uploadBtn3 = document.getElementById('uploadBtn3');
         const imageUpload3 = document.getElementById('imageUpload3');
+
+        const offscreenCanvasCache = new Map();
+        const filterColorTemplates = new Map();
+        const fallbackFilterTemplates = {
+            red: 'rgba(255, 0, 0, $opacity)',
+            green: 'rgba(0, 255, 0, $opacity)',
+            blue: 'rgba(0, 0, 255, $opacity)',
+            yellow: 'rgba(255, 255, 0, $opacity)',
+            purple: 'rgba(128, 0, 128, $opacity)',
+            orange: 'rgba(255, 165, 0, $opacity)'
+        };
+
+        function clamp(value, min, max) {
+            return Math.min(Math.max(value, min), max);
+        }
+
+        function resetContextState(context) {
+            context.setTransform(1, 0, 0, 1, 0, 0);
+            context.globalAlpha = 1;
+            context.globalCompositeOperation = 'source-over';
+            context.filter = 'none';
+            context.shadowColor = 'rgba(0, 0, 0, 0)';
+            context.shadowBlur = 0;
+            context.shadowOffsetX = 0;
+            context.shadowOffsetY = 0;
+        }
+
+        function getOffscreenCanvas(key, width, height) {
+            let entry = offscreenCanvasCache.get(key);
+
+            if (!entry) {
+                const offscreen = document.createElement('canvas');
+                entry = {
+                    canvas: offscreen,
+                    ctx: offscreen.getContext('2d')
+                };
+                offscreenCanvasCache.set(key, entry);
+            }
+
+            if (entry.canvas.width !== width || entry.canvas.height !== height) {
+                entry.canvas.width = width;
+                entry.canvas.height = height;
+            }
+
+            resetContextState(entry.ctx);
+            entry.ctx.clearRect(0, 0, entry.canvas.width, entry.canvas.height);
+
+            return entry;
+        }
+
+        function hexToRgba(hex, alpha = 1) {
+            if (typeof hex !== 'string') {
+                return null;
+            }
+
+            const normalized = hex.startsWith('#') ? hex.slice(1) : hex;
+
+            if (normalized.length !== 6) {
+                return null;
+            }
+
+            const r = parseInt(normalized.slice(0, 2), 16);
+            const g = parseInt(normalized.slice(2, 4), 16);
+            const b = parseInt(normalized.slice(4, 6), 16);
+
+            if ([r, g, b].some(Number.isNaN)) {
+                return null;
+            }
+
+            return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+        }
+
+        function resolveFilterColor(colorId, intensity, customColor) {
+            const opacity = clamp(intensity ?? 0, 0, 1);
+
+            if (colorId === 'none' || opacity === 0) {
+                return null;
+            }
+
+            if (colorId === 'custom') {
+                return hexToRgba(customColor, opacity) ?? customColor;
+            }
+
+            const template = filterColorTemplates.get(colorId) ?? fallbackFilterTemplates[colorId];
+
+            if (!template) {
+                return null;
+            }
+
+            return template.replace('$opacity', opacity);
+        }
+
+        function updateFilterTemplateCache() {
+            filterColorTemplates.clear();
+
+            const options = coverSettings?.defaultSettings?.filters?.options;
+
+            if (!Array.isArray(options)) {
+                return;
+            }
+
+            for (const option of options) {
+                if (option?.id && option?.color) {
+                    filterColorTemplates.set(option.id, option.color);
+                }
+            }
+        }
         
         // Объект для хранения настроек обложек, загружается из JSON
         let coverSettings = null;
@@ -475,7 +582,9 @@
         // Инициализация настроек по умолчанию из JSON
         function initializeDefaultSettings() {
             if (!coverSettings) return;
-            
+
+            updateFilterTemplateCache();
+
             // Применяем настройки фильтров
             const filterSettings = coverSettings.defaultSettings.filters;
             state.topLayerFilter.intensity = filterSettings.defaultIntensity;
@@ -535,16 +644,10 @@
             ctx.clearRect(0, 0, canvas.width, canvas.height);
             
             // Создаем временный canvas для работы
-            const tempCanvas = document.createElement('canvas');
-            tempCanvas.width = canvas.width;
-            tempCanvas.height = canvas.height;
-            const tempCtx = tempCanvas.getContext('2d');
+            const { canvas: tempCanvas, ctx: tempCtx } = getOffscreenCanvas('temp', canvas.width, canvas.height);
             
             // Для кастомного типа обложки мы пропускаем создание маски и просто рисуем слои друг на друга
             if (state.coverType === 'custom') {
-                // Создаем временный холст
-                tempCtx.clearRect(0, 0, tempCanvas.width, tempCanvas.height);
-                
                 // Если фон загружен, рисуем его
                 if (state.images.background) {
                     tempCtx.drawImage(state.images.background, 0, 0, tempCanvas.width, tempCanvas.height);
@@ -568,17 +671,11 @@
                 }
                 
                 // Сохраняем маску из фона
-                const maskCanvas = document.createElement('canvas');
-                maskCanvas.width = canvas.width;
-                maskCanvas.height = canvas.height;
-                const maskCtx = maskCanvas.getContext('2d');
+                const { canvas: maskCanvas, ctx: maskCtx } = getOffscreenCanvas('mask', canvas.width, canvas.height);
                 
                 if (state.images.background) {
                     maskCtx.drawImage(state.images.background, 0, 0, maskCanvas.width, maskCanvas.height);
                 }
-                
-                // Очищаем временный холст и заново рисуем все слои
-                tempCtx.clearRect(0, 0, tempCanvas.width, tempCanvas.height);
                 
                 // Рисуем фон
                 if (state.images.background) {
@@ -606,78 +703,32 @@
             // Рисуем верхний слой (контур) с применением фильтра если он выбран
             if (state.images.topLayer) {
                 // Создаем отдельный canvas для верхнего слоя с фильтром
-                const topLayerCanvas = document.createElement('canvas');
-                topLayerCanvas.width = canvas.width;
-                topLayerCanvas.height = canvas.height;
-                const topLayerCtx = topLayerCanvas.getContext('2d');
-                
+                const { canvas: topLayerCanvas, ctx: topLayerCtx } = getOffscreenCanvas('topLayer', canvas.width, canvas.height);
+
                 // Рисуем верхний слой
                 topLayerCtx.drawImage(state.images.topLayer, 0, 0, topLayerCanvas.width, topLayerCanvas.height);
-                
+
                 // Применяем цветовой фильтр, если он выбран
-                if (state.topLayerFilter.color !== 'none') {
+                const filterColor = resolveFilterColor(
+                    state.topLayerFilter.color,
+                    state.topLayerFilter.intensity,
+                    state.topLayerFilter.customColor
+                );
+
+                if (filterColor) {
                     // Используем выбранный режим наложения
                     topLayerCtx.globalCompositeOperation = state.topLayerFilter.blendMode;
-                    
-                    // Определяем цвет фильтра и его интенсивность
-                    let filterColor;
-                    // Используем заданную пользователем интенсивность
-                    let filterOpacity = state.topLayerFilter.intensity;
-                    
-                    if (state.topLayerFilter.color === 'custom') {
-                        // Для пользовательского цвета, преобразуем HEX в RGB с прозрачностью
-                        const hexColor = state.topLayerFilter.customColor;
-                        const r = parseInt(hexColor.slice(1, 3), 16);
-                        const g = parseInt(hexColor.slice(3, 5), 16);
-                        const b = parseInt(hexColor.slice(5, 7), 16);
-                        filterColor = `rgba(${r}, ${g}, ${b}, ${filterOpacity})`;
-                    } else if (state.topLayerFilter.color !== 'none' && coverSettings) {
-                        // Ищем цвет в настройках
-                        const filterOption = coverSettings.defaultSettings.filters.options.find(
-                            option => option.id === state.topLayerFilter.color
-                        );
-                        
-                        if (filterOption && filterOption.color) {
-                            // Заменяем переменную $opacity на фактическое значение
-                            filterColor = filterOption.color.replace('$opacity', filterOpacity);
-                        }
-                    } else {
-                        // Резервные значения на случай, если настройки не загружены
-                        switch (state.topLayerFilter.color) {
-                            case 'red':
-                                filterColor = 'rgba(255, 0, 0, ' + filterOpacity + ')';
-                                break;
-                            case 'green':
-                                filterColor = 'rgba(0, 255, 0, ' + filterOpacity + ')';
-                                break;
-                            case 'blue':
-                                filterColor = 'rgba(0, 0, 255, ' + filterOpacity + ')';
-                                break;
-                            case 'yellow':
-                                filterColor = 'rgba(255, 255, 0, ' + filterOpacity + ')';
-                                break;
-                            case 'purple':
-                                filterColor = 'rgba(128, 0, 128, ' + filterOpacity + ')';
-                                break;
-                            case 'orange':
-                                filterColor = 'rgba(255, 165, 0, ' + filterOpacity + ')';
-                                break;
-                            default:
-                                filterColor = null;
-                        }
-                    }
-                    
-                    if (filterColor) {
-                        // Применяем цветовой фильтр
-                        topLayerCtx.fillStyle = filterColor;
-                        topLayerCtx.fillRect(0, 0, topLayerCanvas.width, topLayerCanvas.height);
-                        
-                        // После применения цветового фильтра, возвращаем исходную прозрачность (альфа-канал)
-                        topLayerCtx.globalCompositeOperation = 'destination-in';
-                        topLayerCtx.drawImage(state.images.topLayer, 0, 0, topLayerCanvas.width, topLayerCanvas.height);
-                    }
+                    topLayerCtx.fillStyle = filterColor;
+                    topLayerCtx.fillRect(0, 0, topLayerCanvas.width, topLayerCanvas.height);
+
+                    // После применения цветового фильтра, возвращаем исходную прозрачность (альфа-канал)
+                    topLayerCtx.globalCompositeOperation = 'destination-in';
+                    topLayerCtx.drawImage(state.images.topLayer, 0, 0, topLayerCanvas.width, topLayerCanvas.height);
+
+                    // Возвращаем стандартный режим отрисовки
+                    topLayerCtx.globalCompositeOperation = 'source-over';
                 }
-                
+
                 // Рисуем обработанный верхний слой на основной временный холст
                 tempCtx.drawImage(topLayerCanvas, 0, 0);
             }
@@ -687,19 +738,13 @@
                 const { x, y, scale, shadowEnabled } = state.topCustomImage;
                 const width = state.images.topCustom.width * scale;
                 const height = state.images.topCustom.height * scale;
-                
+
                 // Создаем отдельный canvas для логотипа с эффектами
-                const logoCanvas = document.createElement('canvas');
-                logoCanvas.width = width + 80; // Добавляем место для тени
-                logoCanvas.height = height + 80;
-                const logoCtx = logoCanvas.getContext('2d');
-                
+                const { canvas: logoCanvas, ctx: logoCtx } = getOffscreenCanvas('logo', width + 80, height + 80);
+
                 // Подготавливаем изображение с цветовым фильтром, если нужно
-                const processedImage = document.createElement('canvas');
-                processedImage.width = width;
-                processedImage.height = height;
-                const processedCtx = processedImage.getContext('2d');
-                
+                const { canvas: processedImage, ctx: processedCtx } = getOffscreenCanvas('logoProcessed', width, height);
+
                 // Применяем прозрачность, если она задана
                 if (state.logoOpacity !== undefined) {
                     processedCtx.globalAlpha = state.logoOpacity;
@@ -710,41 +755,34 @@
                 
                 // Восстанавливаем прозрачность
                 processedCtx.globalAlpha = 1.0;
-                
+
                 // Применяем цветовой фильтр (наложение), если не normal
                 if (state.logoColorBlendMode !== 'normal') {
                     // Создаем временный canvas для цвета
-                    const colorCanvas = document.createElement('canvas');
-                    colorCanvas.width = width;
-                    colorCanvas.height = height;
-                    const colorCtx = colorCanvas.getContext('2d');
-                    
+                    const { canvas: colorCanvas, ctx: colorCtx } = getOffscreenCanvas('logoColor', width, height);
+
                     // Рисуем оригинальное изображение для получения маски
                     colorCtx.drawImage(state.images.topCustom, 0, 0, width, height);
-                    
+
                     // Применяем выбранный цвет только к непрозрачным пикселям
                     colorCtx.globalCompositeOperation = 'source-in';
-                    
+
                     // Анализируем цвет и корректируем с учетом интенсивности
-                    let color = state.logoColorValue;
-                    
-                    // Если интенсивность меньше 100%, смешиваем с прозрачностью
-                    if (state.logoColorIntensity < 1.0) {
-                        // Преобразуем hex в rgba
-                        const r = parseInt(color.slice(1, 3), 16);
-                        const g = parseInt(color.slice(3, 5), 16);
-                        const b = parseInt(color.slice(5, 7), 16);
-                        color = `rgba(${r}, ${g}, ${b}, ${state.logoColorIntensity})`;
-                    }
-                    
-                    colorCtx.fillStyle = color;
+                    const logoColorIntensity = clamp(state.logoColorIntensity ?? 1, 0, 1);
+                    const overlayColor =
+                        logoColorIntensity < 1
+                            ? hexToRgba(state.logoColorValue, logoColorIntensity) ?? state.logoColorValue
+                            : state.logoColorValue;
+
+                    colorCtx.fillStyle = overlayColor;
                     colorCtx.fillRect(0, 0, width, height);
-                    
+
                     // Накладываем цвет на оригинал с выбранным режимом смешивания
                     processedCtx.globalCompositeOperation = state.logoColorBlendMode;
                     processedCtx.drawImage(colorCanvas, 0, 0);
+                    processedCtx.globalCompositeOperation = 'source-over';
                 }
-                
+
                 // Если тень включена, применяем её
                 if (shadowEnabled) {
                     // Настраиваем тень используя параметры из конфигурации
@@ -776,19 +814,13 @@
                 const { x, y, scale, shadowEnabled } = state.topMostCustomImage;
                 const width = state.images.topMostCustom.width * scale;
                 const height = state.images.topMostCustom.height * scale;
-                
+
                 // Создаем отдельный canvas для доп. картинки с эффектами
-                const topMostCanvas = document.createElement('canvas');
-                topMostCanvas.width = width + 80; // Добавляем место для тени
-                topMostCanvas.height = height + 80;
-                const topMostCtx = topMostCanvas.getContext('2d');
-                
+                const { canvas: topMostCanvas, ctx: topMostCtx } = getOffscreenCanvas('topMost', width + 80, height + 80);
+
                 // Подготавливаем изображение с цветовым фильтром, если нужно
-                const processedTopMost = document.createElement('canvas');
-                processedTopMost.width = width;
-                processedTopMost.height = height;
-                const processedTopMostCtx = processedTopMost.getContext('2d');
-                
+                const { canvas: processedTopMost, ctx: processedTopMostCtx } = getOffscreenCanvas('topMostProcessed', width, height);
+
                 // Применяем прозрачность, если она задана
                 if (state.topImageOpacity !== undefined) {
                     processedTopMostCtx.globalAlpha = state.topImageOpacity;
@@ -803,35 +835,28 @@
                 // Применяем цветовой фильтр (наложение), если не normal
                 if (state.topMostColorBlendMode !== 'normal') {
                     // Создаем временный canvas для цвета
-                    const colorCanvas = document.createElement('canvas');
-                    colorCanvas.width = width;
-                    colorCanvas.height = height;
-                    const colorCtx = colorCanvas.getContext('2d');
-                    
+                    const { canvas: colorCanvas, ctx: colorCtx } = getOffscreenCanvas('topMostColor', width, height);
+
                     // Рисуем оригинальное изображение для получения маски
                     colorCtx.drawImage(state.images.topMostCustom, 0, 0, width, height);
-                    
+
                     // Применяем выбранный цвет только к непрозрачным пикселям
                     colorCtx.globalCompositeOperation = 'source-in';
-                    
+
                     // Анализируем цвет и корректируем с учетом интенсивности
-                    let color = state.topMostColorValue;
-                    
-                    // Если интенсивность меньше 100%, смешиваем с прозрачностью
-                    if (state.topMostColorIntensity < 1.0) {
-                        // Преобразуем hex в rgba
-                        const r = parseInt(color.slice(1, 3), 16);
-                        const g = parseInt(color.slice(3, 5), 16);
-                        const b = parseInt(color.slice(5, 7), 16);
-                        color = `rgba(${r}, ${g}, ${b}, ${state.topMostColorIntensity})`;
-                    }
-                    
-                    colorCtx.fillStyle = color;
+                    const topMostIntensity = clamp(state.topMostColorIntensity ?? 1, 0, 1);
+                    const topMostColor =
+                        topMostIntensity < 1
+                            ? hexToRgba(state.topMostColorValue, topMostIntensity) ?? state.topMostColorValue
+                            : state.topMostColorValue;
+
+                    colorCtx.fillStyle = topMostColor;
                     colorCtx.fillRect(0, 0, width, height);
-                    
+
                     // Накладываем цвет на оригинал с выбранным режимом смешивания
                     processedTopMostCtx.globalCompositeOperation = state.topMostColorBlendMode;
                     processedTopMostCtx.drawImage(colorCanvas, 0, 0);
+                    processedTopMostCtx.globalCompositeOperation = 'source-over';
                 }
                 
                 // Если тень включена, применяем её
@@ -870,20 +895,14 @@
                 // Для кастомного типа проверяем, загружен ли фон
                 if (state.images.background && state.customBackgroundUploaded) {
                     // Если фон с маской загружен пользователем, применяем маскирование
-                    const resultCanvas = document.createElement('canvas');
-                    resultCanvas.width = canvas.width;
-                    resultCanvas.height = canvas.height;
-                    const resultCtx = resultCanvas.getContext('2d');
-                    
+                    const { canvas: resultCanvas, ctx: resultCtx } = getOffscreenCanvas('result', canvas.width, canvas.height);
+
                     // Создаем маску из загруженного фона
-                    const maskCanvas = document.createElement('canvas');
-                    maskCanvas.width = canvas.width;
-                    maskCanvas.height = canvas.height;
-                    const maskCtx = maskCanvas.getContext('2d');
-                    
+                    const { canvas: maskCanvas, ctx: maskCtx } = getOffscreenCanvas('maskResult', canvas.width, canvas.height);
+
                     // Рисуем маску на весь канвас
                     maskCtx.drawImage(state.images.background, 0, 0, maskCanvas.width, maskCanvas.height);
-                    
+
                     // Копируем маску в результирующий канвас
                     resultCtx.drawImage(maskCanvas, 0, 0);
                     
@@ -901,16 +920,10 @@
                 }
             } else {
                 // Для стандартных типов применяем маску
-                const resultCanvas = document.createElement('canvas');
-                resultCanvas.width = canvas.width;
-                resultCanvas.height = canvas.height;
-                const resultCtx = resultCanvas.getContext('2d');
-                
+                const { canvas: resultCanvas, ctx: resultCtx } = getOffscreenCanvas('result', canvas.width, canvas.height);
+
                 // Рисуем маску
-                const maskCanvas = document.createElement('canvas');
-                maskCanvas.width = canvas.width;
-                maskCanvas.height = canvas.height;
-                const maskCtx = maskCanvas.getContext('2d');
+                const { canvas: maskCanvas, ctx: maskCtx } = getOffscreenCanvas('maskResult', canvas.width, canvas.height);
                 
                 if (state.images.background) {
                     maskCtx.drawImage(state.images.background, 0, 0, maskCanvas.width, maskCanvas.height);


### PR DESCRIPTION
## Summary
- reuse cached offscreen canvases and reset drawing contexts to avoid repeated allocations during rendering
- centralize color conversion and filter lookup logic to reduce per-frame branching and parsing
- streamline logo and mask rendering paths to leverage the shared helper utilities

## Testing
- python -m json.tool config/cover-settings.json

------
https://chatgpt.com/codex/tasks/task_e_68e06b4293e08329a65d59cf5d1254ec